### PR TITLE
Adding dynamic marker support

### DIFF
--- a/native/projects/VisualStudio/TraceEventProfilerPlugin.vcxproj
+++ b/native/projects/VisualStudio/TraceEventProfilerPlugin.vcxproj
@@ -27,26 +27,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -70,23 +70,23 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>traceeventprofiler</TargetName>
-    <OutDir>$(SolutionDir)..\..\..\com.unity.traceeventprofiler\plugins\win64</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\com.unity.traceeventprofiler\plugins\win64\</OutDir>
     <IntDir>$(SolutionDir)temp\$(Configuration)\</IntDir>
     <LibraryPath>$(VC_LibraryPath_x64);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>TraceEventProfiler</TargetName>
-    <OutDir>$(SolutionDir)..\..\..\TraceEventSampleProject\Packages\com.unity.traceeventprofiler\plugins\win32</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\TraceEventSampleProject\Packages\com.unity.traceeventprofiler\plugins\win32\</OutDir>
     <IntDir>$(SolutionDir)temp\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>TraceEventProfiler</TargetName>
-    <OutDir>$(SolutionDir)..\..\..\TraceEventSampleProject\Packages\com.unity.traceeventprofiler\plugins\win32</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\TraceEventSampleProject\Packages\com.unity.traceeventprofiler\plugins\win32\</OutDir>
     <IntDir>$(SolutionDir)temp\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>traceeventprofiler</TargetName>
-    <OutDir>$(SolutionDir)..\..\..\com.unity.traceeventprofiler\plugins\win64</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\com.unity.traceeventprofiler\plugins\win64\</OutDir>
     <IntDir>$(SolutionDir)temp\$(Configuration)\</IntDir>
     <LibraryPath>$(VC_LibraryPath_x64);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
@@ -95,6 +95,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -105,6 +106,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -121,6 +123,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -136,6 +139,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/native/src/ProfilerPlugin.cpp
+++ b/native/src/ProfilerPlugin.cpp
@@ -445,10 +445,10 @@ static bool WriteTraceFile(std::string &filename, EventNodeBlock *list, int capt
 			eventValues.clear();
 
             eventValues["ph"] = kEventTypePhaseNames[node.type];
-            long usTime = (long)std::chrono::duration_cast<std::chrono::microseconds>(node.time - gCaptureState.captureStartTime).count();
-            eventValues["ts"] = ToString(usTime);
-            eventValues["tid"] = UInt64ToString(block->threadState->threadId);
-            eventValues["pid"] = "1";
+			uint64_t usTime = std::chrono::duration_cast<std::chrono::microseconds>(node.time - gCaptureState.captureStartTime).count();
+			eventValues["ts"] = UInt64ToString(usTime);
+			eventValues["tid"] = UInt64ToString(block->threadState->threadId);
+			eventValues["pid"] = "1";
 
             switch (node.type)
             {

--- a/native/src/ProfilerPlugin.cpp
+++ b/native/src/ProfilerPlugin.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include <sstream>
 #include <mutex>
+#include <codecvt>
 
 #ifdef _MSC_VER
 #include "windows.h"
@@ -89,6 +90,9 @@ struct ThreadNameData
 
 struct EventNode
 {
+	static const uint32_t kNotDefaultMarker = -1;	// Value for defaultMarkerNameId when this is not a default marker (i.e. a "Profiler.Defautl" dynamic name marker)
+	static const uint32_t kEndDefaultMarker = -2;	// Value for defaultMarkerNameId when this is the end event for a default marker
+
 	std::chrono::time_point<std::chrono::steady_clock> time;
 	union
 	{
@@ -102,12 +106,23 @@ struct EventNode
         const UnityProfilerMarkerDesc *markerDesc; 
 	};
     
+	// If this is a begin event for a default marker (i.e. is a "Profiler.Default" marker that passes the actual dynamic name of the marker in it's metadata) then the category and name Id are stored here
+	// If this is a corresponding end event for a default marker "defaultMarkerNameId" will have the value kEndDefaultMarker (-2)
+	// If this is not a default marker then "defaultMarkerNameId" will have the value kNotDefaultMarker (-1) to indicate that
+	UnityProfilerCategoryId defaultMarkerCategoryId;
+	uint32_t defaultMarkerNameId;
+
     // Either EventType or kUnityProfilerMarkerEventType*
 	uint16_t type; 
 
     // Main thread can check this value to validate the node. Proper memory fencing cannot
     // be used because of the overhead of atomics
 	uint16_t memValidationData;
+
+	EventNode()
+		: defaultMarkerNameId(kNotDefaultMarker)
+	{
+	}
 };
 
 struct ThreadLocalState;
@@ -177,6 +192,7 @@ CaptureState gCaptureState;
 thread_local ThreadLocalState gThreadState;
 static IUnityProfilerCallbacks* s_UnityProfilerCallbacks = nullptr;
 static IUnityProfilerCallbacksV2* s_UnityProfilerCallbacksV2 = nullptr;
+static const UnityProfilerMarkerDesc* s_DefaultMarkerDesc;	// Marker description for the special "Profiler.Default" marker that is used to pass dynamically named markers
 
 inline void InitializeThreadLocal()
 {
@@ -274,8 +290,25 @@ static void UNITY_INTERFACE_API EventCallback(const UnityProfilerMarkerDesc* eve
         node.time = std::chrono::steady_clock::now();
         node.markerDesc = eventDesc;
         node.type = eventType;
+
+			if ((eventType == kUnityProfilerMarkerEventTypeBegin) && (eventDataCount > 2) && (eventDesc != nullptr) && (eventDesc == s_DefaultMarkerDesc))
+			{
+				// Default marker emits UTF16 string as the second metadata parameter so we convert it for our use
+
+				std::u16string u16_str(reinterpret_cast<const char16_t*>(eventData[1].ptr));
+				std::string name = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>{}.to_bytes(u16_str);
+				node.defaultMarkerNameId = RegisterStringInternal(name);
+				node.defaultMarkerCategoryId = static_cast<UnityProfilerCategoryId>(*(static_cast<const uint32_t*>(eventData[2].ptr)));
+			}
+			else if ((eventType == kUnityProfilerMarkerEventTypeEnd) && (eventDesc == s_DefaultMarkerDesc))
+			{
+				node.defaultMarkerNameId = EventNode::kEndDefaultMarker;
+			}
+			else
+				node.defaultMarkerNameId = EventNode::kNotDefaultMarker;
+
         AddEventNode(node, gThreadState, (int)(intptr_t)userData);
-    }
+	}
 }
 
 static void UNITY_INTERFACE_API FlowEventCallback(UnityProfilerFlowEventType flowEventType, uint32_t flowId, void* userData)
@@ -293,6 +326,12 @@ static void UNITY_INTERFACE_API FlowEventCallback(UnityProfilerFlowEventType flo
 
 static void UNITY_INTERFACE_API CreateMarkerCallback(const UnityProfilerMarkerDesc* eventDesc, void* userData)
 {
+	if (s_DefaultMarkerDesc == NULL)
+	{
+		if (strcmp(eventDesc->name, "Profiler.Default") == 0)
+			s_DefaultMarkerDesc = eventDesc;
+	}
+
 	if (gCaptureState.isCaptureActive.load(std::memory_order_relaxed))
 		s_UnityProfilerCallbacks->RegisterMarkerEventCallback(eventDesc, EventCallback, userData);
 }
@@ -445,6 +484,7 @@ static bool WriteTraceFile(std::string &filename, EventNodeBlock *list, int capt
 				continue;
 
 			eventValues.clear();
+			eventName = "";
 
             eventValues["ph"] = kEventTypePhaseNames[node.type];
 			uint64_t usTime = std::chrono::duration_cast<std::chrono::microseconds>(node.time - gCaptureState.captureStartTime).count();
@@ -458,8 +498,17 @@ static bool WriteTraceFile(std::string &filename, EventNodeBlock *list, int capt
             case EventType_End:
             case EventType_Single:
             {
-                eventName = node.markerDesc->name != NULL ? std::string(node.markerDesc->name) : "Unknown Event Name";
-                eventValues["cat"] = std::string("\"") + gCaptureState.categories[node.markerDesc->categoryId] + "\"";
+				if (node.defaultMarkerNameId == EventNode::kNotDefaultMarker)
+				{
+					eventName = node.markerDesc->name != NULL ? std::string(node.markerDesc->name) : "Unknown Event Name";
+					eventValues["cat"] = std::string("\"") + gCaptureState.categories[node.markerDesc->categoryId] + "\"";
+				}
+				else if (node.defaultMarkerNameId != EventNode::kEndDefaultMarker)
+				{
+					std::lock_guard<std::mutex>(gCaptureState.nameListMutex);
+					eventName = gCaptureState.nameList[node.defaultMarkerNameId];
+					eventValues["cat"] = std::string("\"") + gCaptureState.categories[node.defaultMarkerCategoryId] + "\"";
+				}
             } break;
 
             case EventType_FlowBegin:

--- a/native/src/ProfilerPlugin.cpp
+++ b/native/src/ProfilerPlugin.cpp
@@ -425,6 +425,8 @@ static bool WriteTraceFile(std::string &filename, EventNodeBlock *list, int capt
     std::string argStr;
 	bool first = true;
 	
+	MemoryBarrier();
+
 	for(EventNodeBlock *block = list; block != NULL; block = block->next)
 	{
 		// This block is from a previous capture. ignore it

--- a/native/src/ProfilerPlugin.cpp
+++ b/native/src/ProfilerPlugin.cpp
@@ -365,7 +365,10 @@ static EventNodeBlock *DeallocFinalized(EventNodeBlock *list)
 		EventNodeBlock *nextIter = iter->next;
 
 		if (iter->isFinalized)
+		{
 			delete iter;
+			gCaptureState.curMemUsageBytes.fetch_sub(sizeof(EventNodeBlock), std::memory_order_relaxed);
+		}
 		else
 		{
 			iter->next = ret;

--- a/native/src/ProfilerPlugin.cpp
+++ b/native/src/ProfilerPlugin.cpp
@@ -526,7 +526,7 @@ extern "C" int UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API BeginCapture(const cha
 		return 0;
 	}
 
-	gCaptureState.maxMemoryUsageBytes = maxMemUsageMB * 1024 * 1024; // MB to B
+	gCaptureState.maxMemoryUsageBytes = static_cast<uint64_t>(maxMemUsageMB) * 1024 * 1024; // MB to B
 	gCaptureState.captureStartTime = std::chrono::steady_clock::now();
 	gCaptureState.filename = filename;
 	gCaptureState.inFrame = false;


### PR DESCRIPTION
The primary function of this PR is to add support for dynamic markers to the trace event profiler plugin.  These are "Profiler.Default" markers where the actual name and category are passed as metadata and are typically emitted by APIs where the marker name is specified at runtime such as `Profiler.BeginSample().`

There are a number of other changes in this PR, each of which has been entered as a separate commit so they can be cherry picked if not all are desired:

- Visual Studio project file updates:
  - Updated platform toolset from v141 to v142 (VS2017 to VS2019) to support required compiler features for the dynamic marker support.
  - Fixed warning about output folder not ending in a backslash.
  - Enabled warnings-as-errors to remove possibility of missing potentially serious issues
  
- Fixed issue where maximum memory for capture couldn't be set higher than 2 GiB due to use of 32bit int in calculations.  uint64_t is now used to support larger buffer sizes.
 
- Fixed issue where the current total memory usage value wasn't being decreased when event blocks were being freed resulting in it increasing constantly and captures being aborted incorrectly if it passed the upper memory use limit after multiple captures despite memory being deallocated
 
- Fixed issue where timestamps in events were being truncated to 32bit (signed) so any capture longer than 35 minutes was having it's timestamps wrapped round causing issues.
 
- Added a memory barrier before writing the trace file to ensure all event data written by capturing threads is visible to the writing thread.  This is a speculative change as I haven't observed any issues with memory visibility but I added it while tracking other issues down and thought leaving it in there couldn't hurt.